### PR TITLE
Correct regex to normalize filename

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -198,10 +198,7 @@ export default class AppleBooksPlugin extends Plugin {
 
 		for (const [, book] of Object.entries(finalData)) {
 			const highlightsFolderPath = this.settings.highlightsFolder;
-			const fileName = `${book.bookTitle}.md`
-				.replace("\\", " ")
-				.replace("/", " ")
-				.replace(":", " ");
+			const fileName = `${book.bookTitle}.md`.replace(/[\\\/:]/g, " ")
 			const filePath = normalizePath(
 				path.join(highlightsFolderPath, fileName)
 			);


### PR DESCRIPTION
Previously only the first instance of \ / or : was being replaced, this regex replaces all of them.

"11/22/63" is a novel that hits this case. https://www.goodreads.com/en/book/show/10644930